### PR TITLE
added lambda-restify in readme > frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ https://www.quora.com/What-is-serverless-computing
 * [IronFunctions](https://github.com/iron-io/functions) - The Serverless Microservices platform
 * [Kappa](https://github.com/garnaat/kappa) - a command line tool that (hopefully) makes it easier to deploy, update, and test functions for AWS Lambda.
 * [Lambada Framework](https://github.com/lambadaframework/lambadaframework) - JAX-RS implementation for AWS Lambda.
+* [lambda-restify](https://github.com/kksharma1618/lambda-restify) - A restify/expressjs like interface for aws lamda with api gateway event.
 * [Lambdoku](https://github.com/kubek2k/lambdoku) - Heroku-like experience when using AWS Lambda
 * [Python-λ](https://github.com/nficano/python-lambda) - A toolkit for developing and deploying serverless Python code in AWS Lambda
 * [Serverless Framework](http://www.serverless.com) - Build and maintain web, mobile and IoT applications running on AWS Lambda and API Gateway (formerly known as JAWS).


### PR DESCRIPTION
Hey,

I added [lambda-restify](https://github.com/kksharma1618/lambda-restify) in frameworks section.

Lambda restify is an npm module that exposes restify/expressjs like interface when using aws lambda with api gateway. It handles request/response/routing/versioned apis/middlewares. 