### PR TITLE
New course / updates to existing entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ https://www.quora.com/What-is-serverless-computing
 * [Serverless](https://leanpub.com/serverless) - Patterns of Modern Application Design Using Microservices (Amazon Web Services Edition).
 * [Serverless Single Page Apps](https://pragprog.com/book/brapps/serverless-single-page-apps) - The Pragmatic Bookshelf.
 * [Going Serverless](https://www.goingserverless.co/) - Practical guide to building applications with the Serverless Framework.
-* [Serverless Architectures on AWS](https://www.manning.com/books/serverless-architectures-on-aws).
+* [Serverless Architectures on AWS](https://www.manning.com/books/serverless-architectures-on-aws). Teaches you how to build, secure and manage serverless architectures that can power the most demanding web and mobile apps. Written by Peter Sbarski
 * [Building Serverless Architectures](https://www.amazon.co.uk/Building-Serverless-Architectures-Cagatay-Gurturk/dp/1787129195) Book about building serverless applications  in JAVA.
 * [AWS Lambda in Action](https://www.manning.com/books/aws-lambda-in-action) An example-driven tutorial that teaches you how to build applications that use an event-driven approach on the back end.
 * [Serverless Apps with Node and Claudia.js](https://www.manning.com/books/serverless-apps-with-node-and-claudiajs) A book that walks you through building serverless apps on AWS using Node.js and Claudia.js. (early access)
@@ -242,9 +242,10 @@ https://www.quora.com/What-is-serverless-computing
 
 ### Courses
 * [Serverless JavaScript by Example](https://www.packtpub.com/web-development/serverless-javascript-example-video) - Become dexterous with live demonstrations on serverless web development.
+* [AWS Lambda in Motion](https://www.manning.com/livevideo/aws-lambda-in-motion) - An example-driven tutorial that focuses on helping you understand and tackle the operational challenges with running AWS Lambda in production.
+* [Serverless Applications with AWS](https://www.manning.com/livevideo/serverless-applications-with-AWS) - Serverless Applications with AWS teaches you to build serverless applications using AWS Lambda and other cloud-based services. 
 
 ### Workshops
-* [AWS Lambda in Motion](https://www.manning.com/livevideo/aws-lambda-in-motion) - An example-driven tutorial that focuses on helping you understand and tackle the operational challenges with running AWS Lambda in production.
 * [OpenWhisk Workshop](https://www.npmjs.com/package/openwhisk-workshop) - Interactive workshop to learn about building serverless applications with OpenWhisk.
 
 ### Newsletters


### PR DESCRIPTION
Transparently, I work for Manning Publications. I saw your (awesome) list, and thought I'd update with another course I didn't see on the list. I also updated the info on two of the entries.

- Added a link to https://www.manning.com/livevideo/serverless-applications-with-AWS
- Added a little extra info about Serverless Architectures on AWS (book)
- Moved AWS Lambda in Motion (it's a video course) to ### Courses