### PR TITLE
Add kube-fledged

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ https://www.quora.com/What-is-serverless-computing
 * [faas](https://github.com/alexellis/faas) - Run Docker containers as functions on Swarm Mode ([blog post](http://blog.alexellis.io/functions-as-a-service/))
 * [FunctionCI](https://github.com/rgfindl/functionci) - Continuous Integration for AWS Lambdas.
 * [gofn](https://github.com/nuveo/gofn) - Go package for function process via container provider (serverless minimalist)
+* [kube-fledged](https://github.com/senthilrch/kube-fledged) - A K8S add-on for creating and managing a cache of container images directly on cluster worker nodes
 * [Lambda Comments](https://github.com/jimpick/lambda-comments) - Blog commenting system built with AWS Lambda
 * [LambCI](https://github.com/lambci/lambci) - A continuous integration system built on AWS Lambda
 * [LambStatus](https://github.com/ks888/LambStatus) - A status page system built on AWS Lambda ([demo](https://lambstatus.github.io/demo-status/))


### PR DESCRIPTION
kube-fledged is a kubernetes add-on for creating and managing a cache of container images directly on the worker nodes of a kubernetes cluster so pods can start almost instantly. This add-on is useful in serverless computing.

kube-fledged provides CRUD APIs to manage the lifecycle of the image cache, and supports several configurable parameters to customize the functioning as per one's needs.

URL:- https://github.com/senthilrch/kube-fledged