### PR TITLE
Webtasks no longer accepts new sign ups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ https://www.quora.com/What-is-serverless-computing
 * [weblab.io](https://weblab.io) - Microservices at your fingertips.
 * [Peer5](https://www.peer5.com) - The serverless CDN. Limitless, affordable video delivery. More traffic means a stronger network.
 * [StdLib](https://stdlib.com) - Function as a service library and platform.
-* [Auth0 Webtasks](https://webtask.io) - Run code with an HTTP call. No provisioning. No deployment.
+* <s>[Auth0 Webtasks](https://webtask.io)</s> - Run code with an HTTP call. No provisioning. No deployment. (No longer accepting new user sign ups)
 * <s>[Webscripts](https://www.webscript.io)</s> - Scripting on the web. (Shutting down December 15, 2017)
 * [APItools](https://www.apitools.com) - Troubleshoot, Modify, Monitor API traffic.
 * [Surge](http://surge.sh) - Deploy static sites from the command line.


### PR DESCRIPTION
Webtask.io no longer accepts new sign ups. Edited listing to reflect this.