### PR TITLE
Add Stacktape (DevOps-free cloud framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of awesome services, solutions and resources for serverless / nob
 * [Shep](https://github.com/bustlelabs/shep) - A framework for building APIs using AWS API Gateway and Lambda.
 * [Sigma](https://www.slappforge.com/sigma) - An all-in-one, browser-based IDE toolkit for drag-n-drop composing, testing and deploying of serverless applications, with fully automated configuration management.
 * [Sparta](http://gosparta.io) - A framework that transforms a Go application into an AWS Lambda powered microservice.
+* [Stacktape](https://stacktape.com) - DevOps-free cloud framework. Deploy lambdas, containers, databases & more to AWS with 98% less config.
 * [SAM Local](https://github.com/awslabs/aws-sam-local) - Is the AWS CLI tool for managing Serverless applications written with [AWS Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model)
 * [Turtle](https://github.com/iopipe/turtle/) - library for building functional and actor-driven NodeJS apps on Lambda.
 * [Zappa](https://github.com/Miserlou/Zappa) - Serverless Python WSGI with AWS Lambda + API Gateway.


### PR DESCRIPTION
Hi, Stacktape CEO here.

After 2.5 years of development, we're finally launching our product - [Stacktape](https://stacktape.com).

It's a DevOps-free cloud development framework. It allows any (even junior) developer to deploy their apps to AWS with 98% less configuration.
We support 20+ fully-managed infrastructure components, Lambda functions, Containers, SQL databases, MongoDb Atlas clusters, Load balancers, Kafka topics, Batch-jobs, Redis clusters & more.

I've added it to the frameworks section.