### PR TITLE
Include Neon in the list of Serverless databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ A curated list of awesome services, solutions and resources for serverless / nob
 * [Deta Base](https://deta.sh) - A super easy to use production-grade NoSQL database.that supports complex queries and search.
 * [Upstash](https://upstash.com/) - Serverless Database for Redis
 * [HarperDB](https://www.harperdb.io/) - Peer-to-peer database that is independent of hardware and network providers, accommodates both NoSQL and SQL workloads. 
+* [Neon](https://neon.tech) - fully managed serverless PostgreSQL. Neon separates storage and compute to offer modern developer features such as serverless, branching, bottomless storage, and more.
 
 ## Others
 


### PR DESCRIPTION
This PR adds [Neon](https://neon.tech) to the list of serverless databases