### PR TITLE
Add Agent Gateway to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ A curated list of awesome services, solutions and resources for serverless / nob
 * [Riff](https://projectriff.io/) - Kubernetes based serverless framework supporting multiple languages.
 * [FuseLess](https://fuseless.org/) - toolkit for running functions written in CFML (ColdFusion Markup Language) on AWS Lambda.
 * [DropFaaS](https://dropfaas.com/) - Serverless framework for running functions written in any languages.
+* [Agent Gateway](https://github.com/OzorOwn/agent-gateway) - Unified REST API gateway for 39+ serverless AI agent services with OpenAPI specs and free tier.
 
 ## Security
 


### PR DESCRIPTION
## What

Adds [Agent Gateway](https://github.com/OzorOwn/agent-gateway) to the Frameworks section.

## About Agent Gateway

Agent Gateway is a unified REST API gateway that exposes 39+ serverless AI agent services through a single endpoint:

- **Services**: crypto wallets, DeFi trading, code execution (Python/JS/Bash), PDF generation, URL shortening, web scraping, screenshots, webhook inspection, file storage, task queues, secrets management, monitoring
- **Architecture**: Each service runs as an independent serverless-style function behind the gateway
- **Developer experience**: OpenAPI 3.1 specs + Swagger UI on every service, free tier with no signup
- **AI agent integration**: Built-in support for LangChain, CrewAI, and MCP (Model Context Protocol)
- **Discovery**: Standard agent.json and llms.txt endpoints for AI agent discovery