### PR TITLE
Add vask to realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of awesome services, solutions and resources for serverless / nob
 * [Ably](https://www.ably.io/) - Global distributed realtime data delivery platform with pub/sub, presence, device awareness, history, connection state recovery, authentication and encryption.
 * [Pusher](https://pusher.com/) - Build Apps, Not Infrastructure.
 * [Pubnub](https://www.pubnub.com/) - PubNub utilizes a Publish/Subscribe[2] model for realtime data streaming.
+* [Vask](https://vask.dev) - Realtime websockets, Pusher-compatible, no-fan out fees, powered by Cloudflare.
 
 ## Scheduling
 


### PR DESCRIPTION
Adds [vask](https://vask.dev) to the _realtime_ section.

Vask is a new websocket platform powered by Cloudflare Workers, Durable Objects, and their 330 PoPs.

It is free for local development use.